### PR TITLE
 Skip initial whitespace when decoding a dict.

### DIFF
--- a/sjson/__init__.py
+++ b/sjson/__init__.py
@@ -293,7 +293,9 @@ def _decode_dict(stream, delimited=False):
     from collections import OrderedDict
     result = OrderedDict()
 
-    if stream.peek() == b'{':
+    next_char = _skip_whitespace(stream)
+
+    if next_char == b'{':
         stream.skip()
 
     next_char = _skip_whitespace(stream)

--- a/sjson/__init__.py
+++ b/sjson/__init__.py
@@ -471,7 +471,8 @@ def _encode_list(obj, separators, indent, level):
 
 
 def _encode_dict(obj, separators, indent, level):
-    yield '\n'
+    if level > 0:
+        yield '\n'
     yield _indent(level, indent)
     yield '{\n'
     first = True


### PR DESCRIPTION
This fixes cases where there is whitespace before the '{' that
begins the top-level object. Also, omit the newline before '{' when
writing the top-level object.

Either fix would be sufficient on its own to fix the symptom, which
is that applying multiple merges to the same sjson file didn't work
correctly. With this fix, the round-trip behavior is restored, so multiple
edits to the same sjson file work as expected.