### PR TITLE
Fix top import by truncating before rewriting the file.

### DIFF
--- a/modimporter.py
+++ b/modimporter.py
@@ -110,6 +110,7 @@ def addtopimport(base,path):
         lines = basefile.readlines()     
         lines.insert(0, "Import "+"\""+modsrel+"/"+path+"\"\n")  
         basefile.seek(0)                 
+        basefile.truncate()
         basefile.writelines(lines)
 
 ### XML mapping


### PR DESCRIPTION
Otherwise, there may be garbage left after the write point, which can cause the file to fail to load.