### PR TITLE
Fix Context.Call

### DIFF
--- a/Any/ModUtil/ModUtil.lua
+++ b/Any/ModUtil/ModUtil.lua
@@ -2410,9 +2410,8 @@ ModUtil.Metatables.Context = {
 		_ContextInfo.data = contextData
 		_ContextInfo.args = contextArgs
 
-		local callWrap = function( ... ) callContext( ... ) end
-		setfenv( callWrap, contextData )
-		callWrap( table.unpack( contextArgs ) )
+		setfenv( callContext, contextData )
+		callContext( table.unpack( contextArgs ) )
 	end
 }
 


### PR DESCRIPTION
In order for the environment of the target function to be available, it must be directly set on the function provided to Context.Call (and not on a wrapper).